### PR TITLE
Criado requirements.txt e especificado Python 3 nos comandos

### DIFF
--- a/libs/requirements.txt
+++ b/libs/requirements.txt
@@ -1,0 +1,2 @@
+pexpect==4.2.1
+ptyprocess==0.5.2

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "IDE online para o Portugol (UNIVALI)",
   "private": true,
   "scripts": {
-    "preinstall" : "pip install pexpect",
+    "preinstall" : "pip3 install pexpect",
     "start": "nodemon ./bin/www --watch ./",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/sockets/base.js
+++ b/sockets/base.js
@@ -3,7 +3,7 @@ module.exports = function (io){
   var pty = require('pty.js');
   io.on('connection', function(socket){
     var listen = false;
-    var term = pty.spawn('python', ["libs/runtime.py"], {
+    var term = pty.spawn('python3', ["libs/runtime.py"], {
       name: 'xterm',
       cols: 80,
       rows: 30,


### PR DESCRIPTION
`python` no linux é apenas uma alias de `python2` ou `python3`, especificar `python3` vai especificar qual binário utilizar.

Também foi incluído o arquivo com os pacotes específicos utilizados no script em python, é possível instala-los utilizando:
`pip3 install -r requirements.txt`