### PR TITLE
Implementação das operações de Bitwise Shift (Left Shift e Right Shift)

### DIFF
--- a/packages/ide/src/app/tab-start/tab-start.component.html
+++ b/packages/ide/src/app/tab-start/tab-start.component.html
@@ -77,9 +77,9 @@
   <hr />
 
   <h4>📰 Novidades</h4>
+  <p><strong>24/10/2022:</strong> Implementação das operações de <em>Bitwise Shift</em> (<em>Left Shift</em> e <em>Right Shift</em>).</p>
   <p><strong>20/10/2022:</strong> Correção na atribuição de valores às variáveis para garantir as tipagens corretas e correção na exibição de erros em tempo de execução.</p>
   <p><strong>19/10/2022:</strong> Correção ao pressionar <em>backspace</em> e suporte a múltiplos parâmetros na entrada de dados pela função <code>leia</code>.</p>
-  <p><strong>12/10/2022:</strong> Melhorias internas de componentização e organização de código.</p>
 </section>
 
 <footer>

--- a/packages/runtime/src/PortugolJs.ts
+++ b/packages/runtime/src/PortugolJs.ts
@@ -409,7 +409,14 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
   }
 
   visitOperacaoMatematica(
-    ctx: MultiplicacaoContext | DivisaoContext | ModuloContext | AdicaoContext | SubtracaoContext,
+    ctx:
+      | MultiplicacaoContext
+      | DivisaoContext
+      | ModuloContext
+      | AdicaoContext
+      | SubtracaoContext
+      | OperacaoShiftLeftContext
+      | OperacaoShiftRightContext,
   ) {
     const sb = new StringBuilder();
 
@@ -424,6 +431,10 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
         ? "+"
         : ctx instanceof SubtracaoContext
         ? "-"
+        : ctx instanceof OperacaoShiftLeftContext
+        ? "<<"
+        : ctx instanceof OperacaoShiftRightContext
+        ? ">>"
         : "?";
 
     sb.append(this.PAD(), `runtime.mathOperation("${op}", [`, `\n`);
@@ -629,34 +640,20 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
     return sb.toString();
   }
 
-  // TODO
   visitOperacaoShiftLeft(ctx: OperacaoShiftLeftContext) {
     const sb = new StringBuilder();
 
-    if (!PortugolJs.thrown.visitOperacaoShiftLeft) {
-      captureException("visitOperacaoShiftLeft", { extra: { text: ctx.text } });
-      PortugolJs.thrown.visitOperacaoShiftLeft = true;
-    }
-
     sb.append(this.DEBUG(`visitOperacaoShiftLeft`, ctx));
-    sb.append(super.visitChildren(ctx));
+    sb.append(this.visitOperacaoMatematica(ctx));
 
     return sb.toString();
   }
 
-  // TODO
   visitOperacaoShiftRight(ctx: OperacaoShiftRightContext) {
     const sb = new StringBuilder();
 
-    if (!PortugolJs.thrown.visitOperacaoShiftRight) {
-      captureException("visitOperacaoShiftRight", {
-        extra: { text: ctx.text },
-      });
-      PortugolJs.thrown.visitOperacaoShiftRight = true;
-    }
-
     sb.append(this.DEBUG(`visitOperacaoShiftRight`, ctx));
-    sb.append(super.visitChildren(ctx));
+    sb.append(this.visitOperacaoMatematica(ctx));
 
     return sb.toString();
   }

--- a/packages/runtime/src/runtime/PortugolRuntime.ts
+++ b/packages/runtime/src/runtime/PortugolRuntime.ts
@@ -151,13 +151,15 @@ class PortugolRuntime {
       let arg = args.shift().clone();
       console.log("mathOperation.ongoing", { arg, result });
 
-      if (!["real", "inteiro"].includes(arg.type)) {
+      if (!["real", "inteiro"].includes(arg.type) || ([">>", "<<"].includes(op) && (arg.type !== "inteiro" || result.type !== "inteiro"))) {
         const mathOpDesc = {
           "+": ["somar", "à"],
           "-": ["subtrair", "de"],
           "*": ["multiplicar", "por"],
           "/": ["dividir", "por"],
           "%": ["obter o módulo entre", "e"],
+          ">>": ["deslocar os bits para a direita de", "para"],
+          "<<": ["deslocar os bits para a esquerda de", "para"],
         };
 
         const [verb, preposition] = mathOpDesc[op];
@@ -184,6 +186,14 @@ class PortugolRuntime {
 
         case "%":
           result.value %= arg.value;
+          break;
+
+        case ">>":
+          result.value = result.value >> arg.value;
+          break;
+
+        case "<<":
+          result.value = result.value << arg.value;
           break;
 
         default:


### PR DESCRIPTION
Os operadores de bitwise shift não estavam funcionando pois ainda não estavam implementados.

Código de exemplo _(Ajuda -> Expressões -> Operações Bit a Bit -> Operação de Bitwise Shift)_:

```portugol
programa {
  funcao inicio() {
    escreva(23 << 1, "\n", -105 >> 1)
  }
}
```

Resultado esperado:

```
46
-53
Programa finalizado. Tempo de execução: 35 ms
```
