### PR TITLE
Corrigir inicialização de variáveis no laço para

### DIFF
--- a/packages/ide/src/app/tab-start/tab-start.component.html
+++ b/packages/ide/src/app/tab-start/tab-start.component.html
@@ -77,9 +77,9 @@
   <hr />
 
   <h4>📰 Novidades</h4>
+  <p><strong>25/10/2022:</strong> Correção na inicialização de variáveis no laço <em>para</em>.</p>
   <p><strong>24/10/2022:</strong> Implementação das operações de <em>Bitwise Shift</em> (<em>Left Shift</em> e <em>Right Shift</em>) e correção nas operações de Bitwise <em>AND</em>, <em>OR</em> e <em>XOR</em>.</p>
   <p><strong>20/10/2022:</strong> Correção na atribuição de valores às variáveis para garantir as tipagens corretas e correção na exibição de erros em tempo de execução.</p>
-  <p><strong>19/10/2022:</strong> Correção ao pressionar <em>backspace</em> e suporte a múltiplos parâmetros na entrada de dados pela função <code>leia</code>.</p>
 </section>
 
 <footer>

--- a/packages/runtime/src/PortugolJs.ts
+++ b/packages/runtime/src/PortugolJs.ts
@@ -1474,7 +1474,7 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
     const sb = new StringBuilder();
 
     sb.append(this.DEBUG(`visitPara`, ctx));
-    sb.append(this.PAD(), `for (`, `\n`);
+    sb.append(this.PAD(), `{`, `\n`);
 
     this.pad++;
 
@@ -1483,6 +1483,11 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
     if (declr) {
       sb.append(this.visit(declr));
     }
+
+    sb.append(this.PAD(), `;`, `\n`);
+    sb.append(this.PAD(), `for (`, `\n`);
+
+    this.pad++;
 
     sb.append(this.PAD(), `;`, `\n`);
     sb.append(this.visit(ctx.condicao()));
@@ -1496,6 +1501,10 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
     this.pad++;
 
     sb.append(this.visit(ctx.listaComandos()));
+
+    this.pad--;
+
+    sb.append(this.PAD(), `}`, `\n`);
 
     this.pad--;
 


### PR DESCRIPTION
Código de exemplo:

```portugol
programa {
  funcao inicio() {
    para (inteiro i = 1; i <= 2; i++) {
      escreva(i, "\n")
    }
  }
}
```

Antes, o código gerado era:

```js
for (
  scope.variables["i"] = new PortugolVar("inteiro", undefined)
  runtime.assign([
    scope.variables["i"],
    new PortugolVar("inteiro", 1)
  ])
  ;
  // ...
  ;
  // ...
) {
  // ...
} 
```

Com a correção:

```js
{
  scope.variables["i"] = new PortugolVar("inteiro", undefined)
  runtime.assign([
    scope.variables["i"],
    new PortugolVar("inteiro", 1)
  ])
  ;
  for (
    ;
    // ...
    ;
    // ...
  ) {
    // ...
  }
};
```

