### PR TITLE
Corrigir inicialização de Vetor

### DIFF
--- a/packages/ide/src/app/tab-start/tab-start.component.html
+++ b/packages/ide/src/app/tab-start/tab-start.component.html
@@ -77,7 +77,7 @@
   <hr />
 
   <h4>📰 Novidades</h4>
-  <p><strong>26/10/2022:</strong> Correção na declaração de variáveis do tipo <em>vetor</em>.</p>
+  <p><strong>27/10/2022:</strong> Correção na declaração de variáveis do tipo <em>vetor</em>.</p>
   <p><strong>25/10/2022:</strong> Correção na inicialização de variáveis no laço <em>para</em>.</p>
   <p><strong>24/10/2022:</strong> Implementação das operações de <em>Bitwise Shift</em> (<em>Left Shift</em> e <em>Right Shift</em>) e correção nas operações de Bitwise <em>AND</em>, <em>OR</em> e <em>XOR</em>.</p>
 </section>

--- a/packages/ide/src/app/tab-start/tab-start.component.html
+++ b/packages/ide/src/app/tab-start/tab-start.component.html
@@ -77,9 +77,9 @@
   <hr />
 
   <h4>📰 Novidades</h4>
+  <p><strong>26/10/2022:</strong> Correção na declaração de variáveis do tipo <em>vetor</em>.</p>
   <p><strong>25/10/2022:</strong> Correção na inicialização de variáveis no laço <em>para</em>.</p>
   <p><strong>24/10/2022:</strong> Implementação das operações de <em>Bitwise Shift</em> (<em>Left Shift</em> e <em>Right Shift</em>) e correção nas operações de Bitwise <em>AND</em>, <em>OR</em> e <em>XOR</em>.</p>
-  <p><strong>20/10/2022:</strong> Correção na atribuição de valores às variáveis para garantir as tipagens corretas e correção na exibição de erros em tempo de execução.</p>
 </section>
 
 <footer>

--- a/packages/runtime/src/PortugolJs.ts
+++ b/packages/runtime/src/PortugolJs.ts
@@ -1014,8 +1014,8 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
         const init = arr.inicializacaoArray();
 
         if (arr.OP_ATRIBUICAO() && init) {
-          sb.append(this.PAD(), `${scopeStr}.variables["${arr.ID().text}"] = new PortugolVar(`);
-          sb.append(`"vetor", `, this.visit(init).trim(), `)`, `\n`);
+          sb.append(this.PAD(), `${scopeStr}.variables["${arr.ID().text}"] = `);
+          sb.append(this.visit(init).trim(), `\n`);
         } else {
           sb.append(this.PAD(), `${scopeStr}.variables["${arr.ID().text}"] = new PortugolVar(`);
           sb.append(`"vetor", `);


### PR DESCRIPTION
Código de exemplo:

```portugol
programa {
  funcao inicio() {
    inteiro vetor[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };

    para(inteiro posicao = 0; posicao < 10; posicao++) {
      escreva(vetor[posicao], " ")
    }
  }
}
```

Antes, o código gerado era:

```js
scope.variables["vetor"] = new PortugolVar("vetor", new PortugolVar("vetor",
  [
    new PortugolVar("inteiro", 1),
    // ...
    new PortugolVar("inteiro", 10),
  ]
));
```

Com a correção:


```js
scope.variables["vetor"] = new PortugolVar("vetor",
  [
    new PortugolVar("inteiro", 1),
    // ...
    new PortugolVar("inteiro", 10),
  ]
);
```