### PR TITLE
Correção na concatenação de Cadeia e Caracter

### DIFF
--- a/packages/ide/src/app/tab-start/tab-start.component.html
+++ b/packages/ide/src/app/tab-start/tab-start.component.html
@@ -77,7 +77,7 @@
   <hr />
 
   <h4>📰 Novidades</h4>
-  <p><strong>27/10/2022:</strong> Correção na declaração de variáveis do tipo <em>vetor</em>.</p>
+  <p><strong>27/10/2022:</strong> Correção na declaração de variáveis do tipo <em>vetor</em> e correção na concatenação de <em>cadeia</em> e <em>caracter</em>.</p>
   <p><strong>25/10/2022:</strong> Correção na inicialização de variáveis no laço <em>para</em>.</p>
   <p><strong>24/10/2022:</strong> Implementação das operações de <em>Bitwise Shift</em> (<em>Left Shift</em> e <em>Right Shift</em>) e correção nas operações de Bitwise <em>AND</em>, <em>OR</em> e <em>XOR</em>.</p>
 </section>

--- a/packages/runtime/src/runtime/PortugolRuntime.ts
+++ b/packages/runtime/src/runtime/PortugolRuntime.ts
@@ -109,7 +109,7 @@ class PortugolRuntime {
   }
 
   coerceToType(type, value, valueType) {
-    if (valueType !== type && !this.areTypesConvertible(valueType, type)) {
+    if (valueType !== type && !this.canCoerceType(valueType, type)) {
       throw new Error("Tipos incompatíveis! Não é possível atribuir uma expressão do tipo '" + valueType + "' à uma expressão do tipo '" + type + "'.");
     }
 

--- a/packages/runtime/src/runtime/PortugolRuntime.ts
+++ b/packages/runtime/src/runtime/PortugolRuntime.ts
@@ -104,7 +104,7 @@ class PortugolRuntime {
     this.globalScope.libAliases[alias || name] = name;
   }
 
-  areTypesConvertible(from, to) {
+  canCoerceType(from, to) {
     return (from === to || from === "inteiro" && to === "real" || from === "real" && to === "inteiro");
   }
 

--- a/packages/runtime/src/runtime/PortugolRuntime.ts
+++ b/packages/runtime/src/runtime/PortugolRuntime.ts
@@ -126,7 +126,7 @@ class PortugolRuntime {
         return result;
       }
 
-      case "caractere":
+      case "caracter":
         return String(value).charAt(0);
 
       case "cadeia":
@@ -140,10 +140,32 @@ class PortugolRuntime {
     }
   }
 
+  concat(result, args) {
+    console.log("concat.preinit", { result, args });
+
+    while (args.length) {
+      let arg = args.shift().clone();
+      console.log("concat.ongoing", { arg, result });
+
+      if (!["cadeia", "caracter"].includes(arg.type)) {
+        throw new Error("Tipos incompatíveis! Não é possível concatenar uma expressão do tipo '" + result.type + "' (" + result.toString() + ") com uma expressão do tipo '" + arg.type + "' (" + arg.toString() + ").");
+      }
+
+      result.value += arg.value;
+    }
+
+    console.log("concat.finish", { result });
+    return result;
+  }
+
   mathOperation(op, args) {
-    console.log("mathOp.preinit", { op, args });
+    console.log("mathOperation.preinit", { op, args });
 
     let result = args.shift().clone();
+
+    if (op === "+" && result.type === "cadeia") {
+      return self.runtime.concat(result, args);
+    }
 
     console.log("mathOperation.init", { op, args, result });
 

--- a/packages/runtime/src/runtime/PortugolRuntime.ts
+++ b/packages/runtime/src/runtime/PortugolRuntime.ts
@@ -104,12 +104,12 @@ class PortugolRuntime {
     this.globalScope.libAliases[alias || name] = name;
   }
 
-  isTypesConvertible(from, to) {
+  areTypesConvertible(from, to) {
     return (from === to || from === "inteiro" && to === "real" || from === "real" && to === "inteiro");
   }
 
   coerceToType(type, value, valueType) {
-    if (valueType !== type && !this.isTypesConvertible(valueType, type)) {
+    if (valueType !== type && !this.areTypesConvertible(valueType, type)) {
       throw new Error("Tipos incompatíveis! Não é possível atribuir uma expressão do tipo '" + valueType + "' à uma expressão do tipo '" + type + "'.");
     }
 


### PR DESCRIPTION
A concatenação de strings não estava funcionando.

Código de exemplo:

```portugol
programa {
  funcao inicio() {
    escreva("a" + "b")
  }
}
```

Resultado esperado:

```
ab
Programa finalizado. Tempo de execução: 22 ms
```

Resultado obtido:

```
⛔ Tipos incompatíveis! Não é possível somar uma expressão do tipo 'cadeia' ("a") à uma expressão do tipo 'cadeia' ("b").
```