### PR TITLE
Corrigir problema ao utilizar retornos de funções como valores

### DIFF
--- a/packages/ide/src/app/tab-start/tab-start.component.html
+++ b/packages/ide/src/app/tab-start/tab-start.component.html
@@ -77,9 +77,9 @@
   <hr />
 
   <h4>📰 Novidades</h4>
+  <p><strong>30/10/2022:</strong> Correção de problema ao utilizar retornos de funções como valores.</p>
   <p><strong>27/10/2022:</strong> Correção na declaração de variáveis do tipo <em>vetor</em> e correção na concatenação de <em>cadeia</em> e <em>caracter</em>.</p>
   <p><strong>25/10/2022:</strong> Correção na inicialização de variáveis no laço <em>para</em>.</p>
-  <p><strong>24/10/2022:</strong> Implementação das operações de <em>Bitwise Shift</em> (<em>Left Shift</em> e <em>Right Shift</em>) e correção nas operações de Bitwise <em>AND</em>, <em>OR</em> e <em>XOR</em>.</p>
 </section>
 
 <footer>

--- a/packages/runner/src/runners/PortugolWebWorkersRunner.ts
+++ b/packages/runner/src/runners/PortugolWebWorkersRunner.ts
@@ -39,6 +39,12 @@ export class PortugolWebWorkersRunner extends IPortugolRunner {
 
             await exec({
               functions: {
+                __debug: async (...args) => {
+                  for (const arg of args) {
+                    console.debug("➡️ DEBUG", arg);
+                  }
+                },
+
                 limpa: async () => {
                   self.postMessage({ type: "clear" });
                 },

--- a/packages/runtime/src/PortugolJs.ts
+++ b/packages/runtime/src/PortugolJs.ts
@@ -135,7 +135,7 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
     const sb = new StringBuilder();
 
     sb.append(this.DEBUG(`visitChamadaFuncao`, ctx));
-    sb.append(this.PAD(), `await runtime.callFunction(`, `\n`);
+    sb.append(this.PAD(), `(await runtime.callFunction(`, `\n`);
 
     this.pad++;
 
@@ -154,7 +154,7 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
 
     this.pad--;
 
-    sb.append(this.PAD(), `)`, `\n`);
+    sb.append(this.PAD(), `))`, `\n`);
 
     return sb.toString();
   }


### PR DESCRIPTION
Código de exemplo:

```portugol
programa {
  funcao inicio() {
    inteiro x[1] = { 1 };

    escreva(x[ret()])
  }

  funcao ret() {
    retorne 0
  }
}
```

Código gerado:

```js
await runtime.callFunction(
  "escreva",
  "",
  [
    scope.variables["x"].value[
      await runtime.callFunction(
        "ret",
        "",
      ).value
    ],
  ]
);
```

Saída: `⛔ Argumento inválido`

Problema: `.value` precisa ser acessado APÓS o await, nesse caso está sendo acessado antes (`await x().value` = `await (x().value)` != `(await x()).value`)

Com a correção:

```js
(await runtime.callFunction(
  "escreva",
  "",
  [
    scope.variables["x"].value[
      (await runtime.callFunction(
        "ret",
        "",
      )).value
    ],
  ]
));
```

Saída: `1`