### PR TITLE
Adicionar opção para escolher o local do arquivo para salvar

### DIFF
--- a/packages/ide/src/app/tab-editor/tab-editor.component.html
+++ b/packages/ide/src/app/tab-editor/tab-editor.component.html
@@ -62,6 +62,27 @@
   <mat-menu #saveMenu="matMenu">
     <button mat-menu-item disabled>Salvar como</button>
 
+    @if (hasSaveFilePickerSupport) {
+      <button
+        mat-menu-item
+        type="button"
+        (click)="saveFileWithPicker()"
+        aria-label="Escolher um arquivo"
+        gaEvent="editor_save_as_file_picker"
+        gaCategory="Editor"
+        gaLabel="Botão de Salvar como - Ação Escolher um arquivo"
+      >
+        <mat-icon>
+          <svg-icon
+            src="assets/mdi/content-save-move.svg"
+            svgAriaLabel="Ícone de disquete com seta para baixo para ação de escolher um arquivo"
+          ></svg-icon>
+        </mat-icon>
+
+        Escolher um arquivo
+      </button>
+    }
+
     <button
       mat-menu-item
       type="button"

--- a/packages/ide/src/app/tab-editor/tab-editor.component.html
+++ b/packages/ide/src/app/tab-editor/tab-editor.component.html
@@ -75,7 +75,7 @@
         <mat-icon>
           <svg-icon
             src="assets/mdi/content-save-move.svg"
-            svgAriaLabel="Ícone de disquete com seta para baixo para ação de escolher um arquivo"
+            svgAriaLabel="Ícone de disquete com seta para a direita para ação de escolher um arquivo"
           ></svg-icon>
         </mat-icon>
 

--- a/packages/ide/src/app/tab-editor/tab-editor.component.ts
+++ b/packages/ide/src/app/tab-editor/tab-editor.component.ts
@@ -98,7 +98,8 @@ export class TabEditorComponent implements OnInit, OnDestroy {
   };
 
   sharing = false;
-  hasSaveFilePickerSupport = false;
+
+  hasSaveFilePickerSupport = "showSaveFilePicker" in window;
 
   shortcuts: ShortcutInput[] = [
     {
@@ -191,8 +192,6 @@ export class TabEditorComponent implements OnInit, OnDestroy {
         wordWrap: wordWrap ? "on" : "off",
       };
     });
-
-    this.hasSaveFilePickerSupport = "showSaveFilePicker" in window;
   }
 
   ngOnDestroy() {

--- a/packages/ide/src/app/tab-editor/tab-editor.component.ts
+++ b/packages/ide/src/app/tab-editor/tab-editor.component.ts
@@ -298,7 +298,10 @@ export class TabEditorComponent implements OnInit, OnDestroy {
 
   async saveFileWithPicker() {
     const extendedWindowApi = window as IExtendedWindowApi;
-    if (!extendedWindowApi.showSaveFilePicker) return;
+
+    if (!extendedWindowApi.showSaveFilePicker) {
+      return;
+    }
 
     const { blob, fileName } = this.prepareFile("binary");
 
@@ -324,6 +327,10 @@ export class TabEditorComponent implements OnInit, OnDestroy {
         duration: 3000,
       });
     } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        return;
+      }
+
       console.error(error);
 
       this.snack.open("Ocorreu um erro ao salvar o arquivo!", "OK", {

--- a/packages/ide/src/app/tab-editor/tab-editor.component.ts
+++ b/packages/ide/src/app/tab-editor/tab-editor.component.ts
@@ -24,14 +24,7 @@ import { SettingsService } from "../settings.service";
 import { ShareService } from "../share.service";
 import { ThemeService } from "../theme.service";
 import { WorkerService } from "../worker.service";
-
-interface IExtendedWindowApi extends Window {
-  showSaveFilePicker?: (options: {
-    types: Array<{ description: string; accept: Record<string, string[]> }>;
-    excludeAcceptAllOption?: boolean;
-    suggestedName?: string;
-  }) => Promise<FileSystemFileHandle>;
-}
+import { IExtendedWindowApi } from "../../types";
 
 // eslint-disable-next-line @angular-eslint/prefer-standalone
 @Component({

--- a/packages/ide/src/app/tab-start/tab-start.component.html
+++ b/packages/ide/src/app/tab-start/tab-start.component.html
@@ -89,7 +89,8 @@
   <h4><svg-icon src="assets/mdi/newspaper.svg" svgAriaLabel="Ícone de jornal para notícias" />Novidades</h4>
   <p>
     <strong>04/01/2025:</strong> Configurações de exibição do editor de código adicionadas, agora é possível alterar o
-    tamanho da fonte e a quebra de linha.
+    tamanho da fonte e a quebra de linha. Nova opção para escolher o local de salvar o arquivo (somente no Chrome ou
+    Edge).
   </p>
   <p>
     <strong>26/12/2024:</strong> Adicionado o tema claro e a tela de configurações para escolher o tema da IDE, mais

--- a/packages/ide/src/types.ts
+++ b/packages/ide/src/types.ts
@@ -1,0 +1,8 @@
+export interface IExtendedWindowApi extends Window {
+  // https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker
+  showSaveFilePicker?: (options: {
+    types: Array<{ description: string; accept: Record<string, string[]> }>;
+    excludeAcceptAllOption?: boolean;
+    suggestedName?: string;
+  }) => Promise<FileSystemFileHandle>;
+}


### PR DESCRIPTION
Foi adicionada uma opção para escolher o local do arquivo para salvar utilizando a API [window.showSaveFilePicker](https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker) que está disponível somente para o Chrome e o Edge no momento.

O botão de "Escolher um arquivo" só aparece quando essa API existe.

![image](https://github.com/user-attachments/assets/2c62461a-4ae7-472a-b747-c048df3d0c69)