### PR TITLE
Ajuste na transpilação dos operadores lógicos

### DIFF
--- a/packages/antlr/src/PortugolErrorListener.ts
+++ b/packages/antlr/src/PortugolErrorListener.ts
@@ -100,7 +100,7 @@ export class PortugolErrorListener implements ANTLRErrorListener {
     _charPositionInLine: number,
     _msg: string,
     e: RecognitionException | null,
-  ): void {
+  ) {
     this.errors.push(
       PortugolCodeError.fromContext(e?.ctx || offendingSymbol || (null as any), "Código incompleto ou inválido"),
     );

--- a/packages/ide/src/app/dialog-renderer/dialog-renderer.component.html
+++ b/packages/ide/src/app/dialog-renderer/dialog-renderer.component.html
@@ -1,0 +1,11 @@
+<header mat-dialog-title cdkDrag cdkDragHandle cdkDragRootElement=".cdk-overlay-pane">
+  <span>{{ title }}</span>
+  <s></s>
+  <button tabindex="-1" type="button" mat-dialog-close mat-icon-button aria-label="Fechar diálogo">
+    <svg-icon src="assets/mdi/close.svg" svgAriaLabel="Ícone de fechar diálogo" />
+  </button>
+</header>
+
+<mat-dialog-content class="renderer-content">
+  <canvas #canvas></canvas>
+</mat-dialog-content>

--- a/packages/ide/src/app/dialog-renderer/dialog-renderer.component.scss
+++ b/packages/ide/src/app/dialog-renderer/dialog-renderer.component.scss
@@ -1,0 +1,14 @@
+header {
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 1rem;
+  cursor: grab;
+
+  &.cdk-drag-dragging {
+    cursor: grabbing;
+  }
+}
+
+.renderer-content {
+  padding: 0 !important;
+}

--- a/packages/ide/src/app/dialog-renderer/dialog-renderer.component.ts
+++ b/packages/ide/src/app/dialog-renderer/dialog-renderer.component.ts
@@ -1,0 +1,46 @@
+import { DragDropModule } from "@angular/cdk/drag-drop";
+import { Component, ElementRef, Input, ViewChild } from "@angular/core";
+import { MatButtonModule } from "@angular/material/button";
+import { MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle } from "@angular/material/dialog";
+import { AngularSvgIconModule } from "angular-svg-icon";
+import { IGraphicsRendererComponent } from "../../renderer";
+
+@Component({
+  selector: "app-dialog-renderer",
+  imports: [MatButtonModule, MatDialogClose, MatDialogContent, MatDialogTitle, AngularSvgIconModule, DragDropModule],
+  templateUrl: "./dialog-renderer.component.html",
+  styleUrl: "./dialog-renderer.component.scss",
+  standalone: true,
+})
+export class DialogRendererComponent implements IGraphicsRendererComponent {
+  @Input()
+  title = "";
+
+  @ViewChild("canvas")
+  canvas?: ElementRef<HTMLCanvasElement>;
+
+  constructor(public dialogRef: MatDialogRef<DialogRendererComponent>) {}
+
+  getCanvas(): Promise<OffscreenCanvas> {
+    return new Promise(resolve => {
+      const interval = setInterval(() => {
+        if (this.canvas?.nativeElement) {
+          clearInterval(interval);
+          resolve(this.canvas.nativeElement.transferControlToOffscreen());
+        }
+      }, 100);
+    });
+  }
+
+  setTitle(title: string) {
+    this.title = title;
+  }
+
+  setSize(_width: number, _height: number) {
+    // Não precisa fazer nada
+  }
+
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/packages/ide/src/app/tab-start/tab-start.component.html
+++ b/packages/ide/src/app/tab-start/tab-start.component.html
@@ -87,6 +87,7 @@
 
 <section class="info">
   <h4><svg-icon src="assets/mdi/newspaper.svg" svgAriaLabel="Ícone de jornal para notícias" />Novidades</h4>
+  <p><strong>06/01/2025:</strong> Implementação da biblioteca <code>Graficos</code>.</p>
   <p>
     <strong>04/01/2025:</strong> Configurações de exibição do editor de código adicionadas, agora é possível alterar o
     tamanho da fonte e a quebra de linha. Nova opção para escolher o local de salvar o arquivo (somente no Chrome ou
@@ -95,10 +96,6 @@
   <p>
     <strong>26/12/2024:</strong> Adicionado o tema claro e a tela de configurações para escolher o tema da IDE, mais
     configurações vindo em breve.
-  </p>
-  <p>
-    <strong>23/09/2024:</strong> Ajuste na fonte da seção Ajuda para estar disponível offline, mantendo uma boa
-    experiência sem depender de conexão com a internet.
   </p>
 </section>
 

--- a/packages/ide/src/renderer.ts
+++ b/packages/ide/src/renderer.ts
@@ -1,0 +1,133 @@
+import { PortugolExecutor, PortugolMessage } from "@portugol-webstudio/runner";
+
+export interface IGraphicsRendererComponent {
+  close(): void;
+  getCanvas(): Promise<OffscreenCanvas>;
+  setTitle(title: string): void;
+  setSize(width: number, height: number): void;
+}
+
+export class CreateGraphicsRendererComponentEvent extends Event {
+  component?: IGraphicsRendererComponent;
+}
+
+export class GraphicsRenderer extends EventTarget {
+  private executor: PortugolExecutor;
+  private component?: IGraphicsRendererComponent | null;
+  private canvas?: OffscreenCanvas | null;
+
+  constructor(executor: PortugolExecutor) {
+    super();
+    this.executor = executor;
+  }
+
+  destroy() {
+    this.component = null;
+    this.canvas = null;
+  }
+
+  async handleRendererMessage(message: PortugolMessage) {
+    switch (message.type) {
+      case "graphics.create": {
+        await this.createRenderer();
+
+        if (this.canvas) {
+          this.executor.replyMessage(message, this.canvas, [this.canvas]);
+        } else {
+          this.executor.replyMessage(message, null);
+        }
+
+        break;
+      }
+
+      case "graphics.destroy": {
+        this.component?.close();
+        this.destroy();
+        this.executor.replyMessage(message, null);
+        break;
+      }
+
+      case "graphics.setWindowSize": {
+        if (this.component) {
+          const data = message.data as { width: number; height: number };
+          const width = data.width;
+          const height = data.height;
+          this.component.setSize(width, height);
+        }
+
+        this.executor.replyMessage(message, null);
+        break;
+      }
+
+      case "graphics.setWindowTitle": {
+        if (this.component) {
+          const data = message.data as { title: string };
+          const title = data.title;
+          this.component.setTitle(title);
+        }
+
+        this.executor.replyMessage(message, null);
+        break;
+      }
+
+      case "graphics.closeWindow": {
+        this.component?.close();
+        this.executor.replyMessage(message, null);
+        break;
+      }
+
+      case "graphics.showWindow": {
+        this.executor.replyMessage(message, null);
+        break;
+      }
+
+      case "graphics.minimizeWindow": {
+        this.executor.replyMessage(message, null);
+        break;
+      }
+
+      case "graphics.restoreWindow": {
+        this.executor.replyMessage(message, null);
+        break;
+      }
+
+      case "graphics.enterFullscreen": {
+        this.executor.replyMessage(message, null);
+        break;
+      }
+
+      case "graphics.exitFullscreen": {
+        this.executor.replyMessage(message, null);
+        break;
+      }
+
+      case "graphics.getScreenInfo": {
+        this.executor.replyMessage(message, {
+          width: window.screen.width,
+          height: window.screen.height,
+          pixelDepth: window.screen.pixelDepth,
+        });
+
+        break;
+      }
+    }
+  }
+
+  async createRenderer() {
+    const event = new CreateGraphicsRendererComponentEvent("create");
+    this.dispatchEvent(event);
+
+    if (event.component) {
+      this.component = event.component;
+      this.canvas = await event.component.getCanvas();
+    }
+  }
+
+  addEventListener(
+    type: "create",
+    callback: ((event: CreateGraphicsRendererComponentEvent) => void) | null,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    super.addEventListener(type, callback, options);
+  }
+}

--- a/packages/ide/src/styles.scss
+++ b/packages/ide/src/styles.scss
@@ -81,3 +81,7 @@ svg-icon > svg {
 .logo-icon[fill] {
   fill: var(--pws-color-primary);
 }
+
+.portugol-renderer-dialog .mat-mdc-dialog-content {
+  max-height: unset;
+}

--- a/packages/runner/src/runners/IPortugolRunner.ts
+++ b/packages/runner/src/runners/IPortugolRunner.ts
@@ -7,7 +7,14 @@ export type PortugolEvent =
   | { type: "stdIn" }
   | { type: "error"; error: Error }
   | { type: "parseError"; errors: PortugolCodeError[] }
-  | { type: "finish"; time: number };
+  | { type: "finish"; stopped: boolean; time: number }
+  | { type: "message"; message: PortugolMessage };
+
+export type PortugolMessage = {
+  id?: string;
+  type: string;
+  data?: unknown;
+};
 
 export abstract class IPortugolRunner {
   constructor(public byteCode: string) {}
@@ -22,5 +29,8 @@ export abstract class IPortugolRunner {
   abstract running$: Observable<boolean>;
 
   abstract run(): Observable<PortugolEvent>;
-  abstract destroy(): void;
+  abstract destroy(stopped?: boolean): void;
+
+  abstract postMessage(message: PortugolMessage): void;
+  abstract replyMessage(message: PortugolMessage, result: unknown, transferable?: Transferable[]): void;
 }

--- a/packages/runtime/src/PortugolJs.ts
+++ b/packages/runtime/src/PortugolJs.ts
@@ -1,6 +1,11 @@
 import {
+  AdicaoContext,
   ArquivoContext,
   AtribuicaoCompostaContext,
+  AtribuicaoCompostaDivisaoContext,
+  AtribuicaoCompostaMultiplicacaoContext,
+  AtribuicaoCompostaSomaContext,
+  AtribuicaoCompostaSubtracaoContext,
   AtribuicaoContext,
   CaracterContext,
   CasoContext,
@@ -15,6 +20,7 @@ import {
   DeclaracaoVariavelContext,
   DecrementoUnarioPosfixadoContext,
   DecrementoUnarioPrefixadoContext,
+  DivisaoContext,
   EnquantoContext,
   EscolhaContext,
   EscopoBibliotecaContext,
@@ -26,6 +32,7 @@ import {
   IncrementoUnarioPosfixadoContext,
   IncrementoUnarioPrefixadoContext,
   IndiceArrayContext,
+  InicializacaoArrayContext,
   InicializacaoMatrizContext,
   InicializacaoParaContext,
   LinhaMatrizContext,
@@ -35,35 +42,12 @@ import {
   ListaParametrosContext,
   MaisUnarioContext,
   MenosUnarioContext,
+  ModuloContext,
+  MultiplicacaoContext,
   NegacaoBitwiseContext,
   NegacaoContext,
   NumeroInteiroContext,
   NumeroRealContext,
-  ParaContext,
-  ParametroArrayContext,
-  ParametroContext,
-  ParametroFuncaoContext,
-  ParametroMatrizContext,
-  PareContext,
-  ReferenciaArrayContext,
-  ReferenciaMatrizContext,
-  ReferenciaParaVariavelContext,
-  RetorneContext,
-  SeContext,
-  SenaoContext,
-  StringContext,
-  TamanhoArrayContext,
-  ValorLogicoContext,
-  PortugolVisitor,
-  AdicaoContext,
-  AtribuicaoCompostaDivisaoContext,
-  AtribuicaoCompostaMultiplicacaoContext,
-  AtribuicaoCompostaSomaContext,
-  AtribuicaoCompostaSubtracaoContext,
-  DivisaoContext,
-  InicializacaoArrayContext,
-  ModuloContext,
-  MultiplicacaoContext,
   OperacaoAndBitwiseContext,
   OperacaoDiferencaContext,
   OperacaoELogicoContext,
@@ -77,10 +61,26 @@ import {
   OperacaoShiftLeftContext,
   OperacaoShiftRightContext,
   OperacaoXorContext,
+  ParaContext,
+  ParametroArrayContext,
+  ParametroContext,
+  ParametroFuncaoContext,
+  ParametroMatrizContext,
+  PareContext,
+  PortugolVisitor,
+  ReferenciaArrayContext,
+  ReferenciaMatrizContext,
+  ReferenciaParaVariavelContext,
+  RetorneContext,
+  SeContext,
+  SenaoContext,
+  StringContext,
   SubtracaoContext,
+  TamanhoArrayContext,
+  ValorLogicoContext,
 } from "@portugol-webstudio/antlr";
 import { captureException } from "@sentry/core";
-import { ParserRuleContext, AbstractParseTreeVisitor } from "antlr4ng";
+import { AbstractParseTreeVisitor, ParserRuleContext } from "antlr4ng";
 
 import { StringBuilder } from "./utils/StringBuilder.js";
 
@@ -581,20 +581,22 @@ export class PortugolJs extends AbstractParseTreeVisitor<string> implements Port
                             ? "^"
                             : "?";
 
-    sb.append(this.PAD(), `runtime.comparativeOperation("${op}", [`, `\n`);
+    sb.append(this.PAD(), `new PortugolVar("logico", (`, `\n`);
 
     this.pad++;
 
     const exprs = ctx.expressao();
 
-    for (const expr of exprs) {
-      sb.append(super.visit(expr)?.trimEnd());
-      sb.append(",", `\n`);
+    for (let i = 0; i < exprs.length; i++) {
+      sb.append(super.visit(exprs[i])?.trimEnd(), `.value`);
+      if (i < exprs.length - 1) {
+        sb.append(` ${op} `, `\n`);
+      }
     }
 
     this.pad--;
 
-    sb.append(this.PAD(), `])`, `\n`);
+    sb.append(`\n`, this.PAD(), `))`, `\n`);
 
     return sb.toString();
   }

--- a/packages/runtime/src/graphics/PortugolGraphicsContext.ts
+++ b/packages/runtime/src/graphics/PortugolGraphicsContext.ts
@@ -1,0 +1,591 @@
+export const portugolGraphicsContext = /* javascript */ `
+class PortugolGraphicsContext {
+  width = 800;
+  height = 600;
+
+  workingFillMode = 0; // 0 = color, 1 = gradient
+  workingColor = 0;
+  workingOpacity = 255;
+  workingRotation = 0;
+  workingGradient = {
+    type: 0,
+    colorA: 0,
+    colorB: 0,
+  };
+
+  workingTextFont = "serif";
+  workingTextSize = 14;
+  workingTextStyle = {
+    bold: false,
+    italic: false,
+    underline: false,
+  };
+
+  drawCalls = [];
+
+  init(canvas) {
+    if (!canvas) {
+      throw new Error("Não foi possível inicializar o contexto gráfico");
+    }
+
+    this.canvas = canvas;
+    this.canvasContext = canvas.getContext("2d");
+  }
+
+  getWidth() {
+    if (this.canvas) {
+      return this.canvas.width;
+    }
+
+    return this.width;
+  }
+
+  getHeight() {
+    if (this.canvas) {
+      return this.canvas.height;
+    }
+
+    return this.height;
+  }
+
+  resize(width, height) {
+    this.width = width;
+    this.height = height;
+
+    if (this.canvas) {
+      this.canvas.width = width;
+      this.canvas.height = height;
+    }
+  }
+
+  getWorkingColor() {
+    return this.workingColor;
+  }
+
+  setWorkingColor(color) {
+    this.drawCall(() => {
+      this.workingColor = color;
+      this.workingFillMode = 0;
+    });
+  }
+
+  setWorkingColorFromRGBA(r, g, b, a) {
+    this.drawCall(() => {
+      const alpha = (a === undefined || a === null) ? 255 : a;
+      const value = ((alpha & 0xFF) << 24) |
+        ((r & 0xFF) << 16) |
+        ((g & 0xFF) << 8) |
+        ((b & 0xFF) << 0);
+      this.workingColor = value;
+    });
+  }
+
+  colorToRGBA(color) {
+    return {
+      a: (color >> 24) & 0xFF,
+      r: (color >> 16) & 0xFF,
+      g: (color >> 8) & 0xFF,
+      b: (color >> 0) & 0xFF,
+    };
+  }
+
+  getWorkingColorAsRGBA() {
+    return this.colorToRGBA(this.workingColor);
+  }
+
+  colorToHex(color) {
+    const componentToHex = (c) => {
+      const hex = c.toString(16);
+      return hex.length == 1 ? "0" + hex : hex;
+    };
+
+    const { r, g, b } = this.colorToRGBA(color);
+
+    return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+  }
+
+  getWorkingColorAsHex() {
+    return this.colorToHex(this.workingColor);
+  }
+
+  setWorkingGradient(type, colorA, colorB) {
+    this.drawCall(() => {
+      this.workingGradient.type = type;
+      this.workingGradient.colorA = colorA;
+      this.workingGradient.colorB = colorB;
+      this.workingFillMode = 1;
+    });
+  }
+
+  getWorkingOpacity() {
+    return this.workingOpacity;
+  }
+
+  getWorkingOpacityAsRange1() {
+    return this.workingOpacity / 255;
+  }
+
+  setWorkingOpacity(opacity) {
+    this.drawCall(() => {
+      this.workingOpacity = opacity;
+    });
+  }
+
+  setWorkingTextStyle(italic, bold, underline) {
+    this.drawCall(() => {
+      this.workingTextStyle.italic = italic;
+      this.workingTextStyle.bold = bold;
+      this.workingTextStyle.underline = underline;
+    });
+  }
+
+  getWorkingTextStyle() {
+    return this.workingTextStyle;
+  }
+
+  setWorkingTextSize(size) {
+    this.drawCall(() => {
+      this.workingTextSize = size;
+    });
+  }
+
+  getWorkingTextSize() {
+    return this.workingTextSize;
+  }
+
+  setWorkingFont(font) {
+    this.drawCall(() => {
+      this.workingTextFont = font;
+    });
+  }
+
+  getWorkingFont() {
+    return this.workingTextFont;
+  }
+
+  setWorkingRotation(rotation) {
+    this.drawCall(() => {
+      this.workingRotation = rotation;
+    });
+  }
+
+  getWorkingRotation() {
+    return this.workingRotation;
+  }
+
+  getWorkingRotationInRadians() {
+    return this.workingRotation * Math.PI / 180;
+  }
+
+  drawCall(drawFunc) {
+    this.drawCalls.push(drawFunc);
+  }
+
+  applyWorkParams(ignoreRotation, objectBounds) {
+    if (this.canvasContext) {
+      const targetBounds = objectBounds ? {
+        ...objectBounds,
+      } : {
+        x: 0,
+        y: 0,
+        width: this.canvas.width,
+        height: this.canvas.height
+      };
+
+      if (this.workingFillMode === 1) {
+        const colorAHex = this.colorToHex(this.workingGradient.colorA);
+        const colorBHex = this.colorToHex(this.workingGradient.colorB);
+
+        let gradient = null;
+
+        switch (this.workingGradient.type) {
+          case 0: { // GRADIENTE_DIREITA
+            gradient = this.canvasContext.createLinearGradient(
+              targetBounds.x + targetBounds.width,
+              targetBounds.y,
+              targetBounds.x,
+              targetBounds.y
+            );
+
+            gradient.addColorStop(0, colorBHex);
+            gradient.addColorStop(1, colorAHex);
+            break;
+          }
+
+          case 1: { // GRADIENTE_ESQUERDA
+            gradient = this.canvasContext.createLinearGradient(
+              targetBounds.x + targetBounds.width,
+              targetBounds.y,
+              targetBounds.x,
+              targetBounds.y
+            );
+
+            gradient.addColorStop(0, colorAHex);
+            gradient.addColorStop(1, colorBHex);
+            break;
+          }
+
+          case 2: { // GRADIENTE_ACIMA
+            gradient = this.canvasContext.createLinearGradient(
+              targetBounds.x,
+              targetBounds.y + targetBounds.height,
+              targetBounds.x,
+              targetBounds.y
+            );
+
+            gradient.addColorStop(0, colorAHex);
+            gradient.addColorStop(1, colorBHex);
+            break;
+          }
+
+          case 3: { // GRADIENTE_ABAIXO
+            gradient = this.canvasContext.createLinearGradient(
+              targetBounds.x,
+              targetBounds.y + targetBounds.height,
+              targetBounds.x,
+              targetBounds.y
+            );
+
+            gradient.addColorStop(0, colorBHex);
+            gradient.addColorStop(1, colorAHex);
+            break;
+          }
+
+          case 4: { // GRADIENTE_INFERIOR_DIREITO
+            gradient = this.canvasContext.createLinearGradient(
+              targetBounds.x,
+              targetBounds.y,
+              targetBounds.x + targetBounds.width,
+              targetBounds.y + targetBounds.height
+            );
+
+            gradient.addColorStop(0, colorAHex);
+            gradient.addColorStop(1, colorBHex);
+            break;
+          }
+
+          case 5: { // GRADIENTE_INFERIOR_ESQUERDO
+            gradient = this.canvasContext.createLinearGradient(
+              targetBounds.x,
+              targetBounds.y,
+              targetBounds.x + targetBounds.width,
+              targetBounds.y + targetBounds.height
+            );
+
+            gradient.addColorStop(0, colorBHex);
+            gradient.addColorStop(1, colorAHex);
+            break;
+          }
+
+          case 6: { // GRADIENTE_SUPERIOR_DIREITO
+            gradient = this.canvasContext.createLinearGradient(
+              targetBounds.x,
+              targetBounds.y + targetBounds.height,
+              targetBounds.x + targetBounds.width,
+              targetBounds.y
+            );
+
+            gradient.addColorStop(0, colorAHex);
+            gradient.addColorStop(1, colorBHex);
+            break;
+          }
+
+          case 7: { // GRADIENTE_SUPERIOR_ESQUERDO
+            gradient = this.canvasContext.createLinearGradient(
+              targetBounds.x,
+              targetBounds.y + targetBounds.height,
+              targetBounds.x + targetBounds.width,
+              targetBounds.y
+            );
+
+            gradient.addColorStop(0, colorBHex);
+            gradient.addColorStop(1, colorAHex);
+            break;
+          }
+
+          default: {
+            gradient = this.canvasContext.createLinearGradient(
+              targetBounds.x + targetBounds.width,
+              targetBounds.y,
+              targetBounds.x,
+              targetBounds.y
+            );
+
+            gradient.addColorStop(0, colorBHex);
+            gradient.addColorStop(1, colorAHex);
+            break;
+          }
+        }
+
+        this.canvasContext.strokeStyle = gradient;
+        this.canvasContext.fillStyle = gradient;
+      } else {
+        const hexColor = this.getWorkingColorAsHex();
+        this.canvasContext.strokeStyle = hexColor;
+        this.canvasContext.fillStyle = hexColor;
+      }
+
+      this.canvasContext.globalAlpha = this.getWorkingOpacityAsRange1();
+
+      this.canvasContext.font =
+        (this.workingTextStyle.italic ? "italic " : "") +
+        (this.workingTextStyle.bold ? "bold " : "") +
+        this.workingTextSize + "px " +
+        this.workingTextFont;
+
+      const rotation = this.getWorkingRotationInRadians();
+      this.canvasContext.setTransform(1, 0, 0, 1, 0, 0);
+
+      if (!ignoreRotation && rotation > 0) {
+        if (objectBounds) {
+          const { x, y, width, height } = objectBounds;
+          this.canvasContext.translate(x + (width / 2), y + (height / 2));
+        }
+
+        this.canvasContext.rotate(rotation);
+      }
+    }
+  }
+
+  applyTransformationToBounds(objectBounds) {
+    const rotation = this.getWorkingRotationInRadians();
+
+    if (rotation > 0) {
+      return {
+        x: -(objectBounds.width / 2),
+        y: -(objectBounds.height / 2),
+        width: objectBounds.width,
+        height: objectBounds.height,
+      };
+    }
+
+    return objectBounds;
+  }
+
+  render() {
+    return new Promise((resolve) => {
+      self.requestAnimationFrame(() => {
+        while (this.drawCalls.length > 0) {
+          this.drawCalls.shift()?.();
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  clearRender() {
+    this.drawCall(() => {
+      if (this.canvas && this.canvasContext) {
+        this.applyWorkParams(true);
+        this.canvasContext.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.canvasContext.fillRect(0, 0, this.canvas.width, this.canvas.height);
+      }
+    });
+  }
+
+  drawRect(x, y, width, height, rounded, fill) {
+    this.drawCall(() => {
+      if (this.canvasContext) {
+        const bounds = {
+          x,
+          y,
+          width,
+          height,
+        };
+
+        this.applyWorkParams(false, bounds);
+
+        const { x: rx, y: ry, width: rwidth, height: rheight } = this.applyTransformationToBounds(bounds);
+
+        if (rounded) {
+          this.canvasContext.beginPath();
+          this.canvasContext.roundRect(rx, ry, rwidth, rheight, 5);
+          this.canvasContext.closePath();
+
+          if (fill) {
+            this.canvasContext.fill();
+          } else {
+            this.canvasContext.stroke();
+          }
+        } else {
+          if (fill) {
+            this.canvasContext.fillRect(rx, ry, rwidth, rheight);
+          } else {
+            this.canvasContext.strokeRect(rx, ry, rwidth, rheight);
+          }
+        }
+      }
+    });
+  }
+
+  drawEllipse(x, y, width, height, fill) {
+    this.drawCall(() => {
+      if (this.canvasContext) {
+        const bounds = {
+          x,
+          y,
+          width,
+          height,
+        };
+
+        this.applyWorkParams(false, bounds);
+
+        const { x: rx, y: ry, width: rwidth, height: rheight } = this.applyTransformationToBounds(bounds);
+
+        this.canvasContext.beginPath();
+        this.canvasContext.ellipse(rx + (rwidth / 2), ry + (rheight / 2), rwidth / 2, rheight / 2, 0, 0, 2 * Math.PI);
+        this.canvasContext.closePath();
+
+        if (fill) {
+          this.canvasContext.fill();
+        } else {
+          this.canvasContext.stroke();
+        }
+      }
+    });
+  }
+
+  drawPoint(x, y) {
+    this.drawCall(() => {
+      if (this.canvasContext) {
+        this.applyWorkParams(true);
+        this.canvasContext.fillRect(x, y, 1, 1);
+      }
+    });
+  }
+
+  calculatePolygonArea(points) {
+    let minX, minY, maxX, maxY;
+
+    points.forEach((point, index) => {
+      if (index === 0) {
+        minX = point[0];
+        minY = point[1];
+        maxX = point[0];
+        maxY = point[1];
+      } else {
+        minX = Math.min(minX, point[0]);
+        minY = Math.min(minY, point[1]);
+        maxX = Math.max(maxX, point[0]);
+        maxY = Math.max(maxY, point[1]);
+      }
+    });
+
+    return {
+      x: minX,
+      y: minY,
+      width: maxX - minX,
+      height: maxY - minY,
+    };
+  }
+
+  applyTransformationToPolygon(points, bounds) {
+    const rotation = this.getWorkingRotationInRadians();
+
+    if (rotation > 0) {
+      return points.map((point) => [
+        point[0] - bounds.x - (bounds.width / 2),
+        point[1] - bounds.y - (bounds.height / 2)
+      ]);
+    }
+
+    return points;
+  }
+
+  drawPolygon(points, fill) {
+    this.drawCall(() => {
+      if (this.canvasContext && points.length > 0) {
+        const bounds = this.calculatePolygonArea(points);
+
+        this.applyWorkParams(false, bounds);
+
+        const rpoints = this.applyTransformationToPolygon(points, bounds);
+
+        this.canvasContext.beginPath();
+
+        rpoints.forEach((point, index) => {
+          if (index === 0) {
+            this.canvasContext.moveTo(point[0], point[1]);
+          } else {
+            this.canvasContext.lineTo(point[0], point[1]);
+          }
+        });
+
+        this.canvasContext.closePath();
+
+        if (fill) {
+          this.canvasContext.fill();
+        } else {
+          this.canvasContext.stroke();
+        }
+      }
+    });
+  }
+
+  calculateTextSize(text) {
+    if (this.canvasContext) {
+      this.applyWorkParams(true);
+      return this.canvasContext.measureText(text);
+    }
+
+    return { width: 0, height: 0 };
+  }
+
+  drawText(x, y, text) {
+    this.drawCall(() => {
+      if (this.canvasContext) {
+        const { width, height } = this.calculateTextSize(text);
+
+        const bounds = {
+          x,
+          y,
+          width,
+          height,
+        };
+
+        this.applyWorkParams(false, bounds);
+
+        const { x: rx, y: ry, width: rwidth, height: rheight } = this.applyTransformationToBounds(bounds);
+
+        this.canvasContext.fillText(text, rx, ry);
+
+        if (this.workingTextStyle.underline) {
+          const underlineBounds = {
+            x,
+            y,
+            width,
+            height: 1,
+          };
+
+          this.applyWorkParams(false, underlineBounds);
+
+          const { x: rux, y: ruy, width: ruwidth, height: ruheight } = this.applyTransformationToBounds(underlineBounds);
+
+          this.canvasContext.fillRect(rux, ruy, ruwidth, ruheight);
+        }
+      }
+    });
+  }
+
+  drawLine(x1, y1, x2, y2) {
+    this.drawCall(() => {
+      if (this.canvasContext) {
+        this.applyWorkParams(false, {
+          x: Math.min(x1, x2),
+          y: Math.min(y1, y2),
+          width: Math.abs(x2 - x1),
+          height: Math.abs(y2 - y1),
+        });
+
+        this.canvasContext.beginPath();
+        this.canvasContext.moveTo(x1, y1);
+        this.canvasContext.lineTo(x2, y2);
+        this.canvasContext.closePath();
+        this.canvasContext.stroke();
+      }
+    });
+  }
+}
+//endregion
+`;

--- a/packages/runtime/src/graphics/index.ts
+++ b/packages/runtime/src/graphics/index.ts
@@ -1,0 +1,1 @@
+export * from "./PortugolGraphicsContext.js";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./graphics/index.js";
 export * from "./PortugolJs.js";
 export { runtime as PortugolJsRuntime } from "./runtime/index.js";

--- a/packages/runtime/src/libs/Graficos.ts
+++ b/packages/runtime/src/libs/Graficos.ts
@@ -1,0 +1,480 @@
+export default /* javascript */ `{
+  CANAL_R: new PortugolVar("inteiro", 0, false, true),
+  CANAL_G: new PortugolVar("inteiro", 1, false, true),
+  CANAL_B: new PortugolVar("inteiro", 2, false, true),
+
+  COR_AMARELO: new PortugolVar("inteiro", -256, false, true),
+  COR_AZUL: new PortugolVar("inteiro", -16776961, false, true),
+  COR_BRANCO: new PortugolVar("inteiro", -1, false, true),
+  COR_PRETO: new PortugolVar("inteiro", -16777216, false, true),
+  COR_VERMELHO: new PortugolVar("inteiro", -65536, false, true),
+  COR_VERDE: new PortugolVar("inteiro", -16711936, false, true),
+
+  GRADIENTE_DIREITA: new PortugolVar("inteiro", 0, false, true),
+  GRADIENTE_ESQUERDA: new PortugolVar("inteiro", 1, false, true),
+  GRADIENTE_ACIMA: new PortugolVar("inteiro", 2, false, true),
+  GRADIENTE_ABAIXO: new PortugolVar("inteiro", 3, false, true),
+  GRADIENTE_INFERIOR_DIREITO: new PortugolVar("inteiro", 4, false, true),
+  GRADIENTE_INFERIOR_ESQUERDO: new PortugolVar("inteiro", 5, false, true),
+  GRADIENTE_SUPERIOR_DIREITO: new PortugolVar("inteiro", 6, false, true),
+  GRADIENTE_SUPERIOR_ESQUERDO: new PortugolVar("inteiro", 7, false, true),
+
+  async iniciar_modo_grafico(manter_visivel) {
+    self.runtime.expectType("iniciar_modo_grafico", "manter_visivel", manter_visivel, "logico");
+
+    const canvas = await self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.create",
+    });
+
+    if (!self.graphics) {
+      self.graphics = new PortugolGraphicsContext();
+    }
+
+    self.graphics.init(canvas);
+  },
+
+  async encerrar_modo_grafico() {
+    self.runtime.assertGraphicsContext();
+
+    await self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.destroy",
+    });
+
+    if (self.graphics) {
+      self.graphics = null;
+    }
+  },
+
+  async fechar_janela() {
+    self.runtime.assertGraphicsContext();
+
+    await self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.closeWindow",
+    });
+  },
+
+  async exibir_borda_janela() {
+    self.runtime.assertGraphicsContext();
+
+    await self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.showWindow",
+    });
+  },
+
+  async minimizar_janela() {
+    self.runtime.assertGraphicsContext();
+
+    await self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.minimizeWindow",
+    });
+  },
+
+  async restaurar_janela() {
+    self.runtime.assertGraphicsContext();
+
+    await self.runtime.waitForResponse({
+      type: "graphics.restoreWindow",
+    });
+  },
+
+  async definir_dimensoes_janela(largura, altura) {
+    self.runtime.expectType("definir_dimensoes_janela", "largura", largura, "inteiro", "real");
+    self.runtime.expectType("definir_dimensoes_janela", "altura", altura, "inteiro", "real");
+
+    self.runtime.assertGraphicsContext();
+
+    const width = Math.round(largura.getValue());
+    const height = Math.round(altura.getValue());
+
+    self.graphics.resize(width, height);
+
+    await self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.setWindowSize",
+      data: {
+        width,
+        height,
+      },
+    });
+  },
+
+  async definir_titulo_janela(titulo) {
+    self.runtime.expectType("definir_titulo_janela", "titulo", titulo, "cadeia");
+
+    self.runtime.assertGraphicsContext();
+
+    await self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.setWindowTitle",
+      data: {
+        title: titulo.getValue(),
+      },
+    });
+  },
+
+  entrar_modo_tela_cheia() {
+    self.runtime.assertGraphicsContext();
+
+    self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.enterFullscreen",
+    });
+  },
+
+  sair_modo_tela_cheia() {
+    self.runtime.assertGraphicsContext();
+
+    self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.exitFullscreen",
+    });
+  },
+
+  largura_janela() {
+    self.runtime.assertGraphicsContext();
+    return new PortugolVar("inteiro", self.graphics.getWidth(), false, true);
+  },
+
+  altura_janela() {
+    self.runtime.assertGraphicsContext();
+    return new PortugolVar("inteiro", self.graphics.getHeight(), false, true);
+  },
+
+  async largura_tela() {
+    const result = await self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.getScreenInfo",
+    });
+
+    return new PortugolVar("inteiro", result.width, false, true);
+  },
+
+  async altura_tela() {
+    const result = await self.runtime.postMessageAndWaitForResponse({
+      type: "graphics.getScreenInfo",
+    });
+
+    return new PortugolVar("inteiro", result.height, false, true);
+  },
+
+  largura_texto(texto) {
+    self.runtime.expectType("largura_texto", "texto", texto, "cadeia");
+    self.runtime.assertGraphicsContext();
+
+    const size = self.graphics.calculateTextSize(texto.getValue());
+    return new PortugolVar("inteiro", size.width, false, true);
+  },
+
+  altura_texto(texto) {
+    self.runtime.expectType("altura_texto", "texto", texto, "cadeia");
+    self.runtime.assertGraphicsContext();
+
+    const size = self.graphics.calculateTextSize(texto.getValue());
+    return new PortugolVar("inteiro", size.height, false, true);
+  },
+
+  async renderizar() {
+    self.runtime.assertGraphicsContext();
+    await self.graphics.render();
+  },
+
+  criar_cor(r, g, b) {
+    self.runtime.expectType("criar_cor", "r", r, "inteiro");
+    self.runtime.expectType("criar_cor", "g", g, "inteiro");
+    self.runtime.expectType("criar_cor", "b", b, "inteiro");
+
+    if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) {
+      throw new Error("Erro ao criar a cor, os valor dos tons deve estar entre 0 e 255");
+    }
+
+    const alpha = 255;
+    const value = ((alpha & 0xFF) << 24) |
+      ((r.getValue() & 0xFF) << 16) |
+      ((g.getValue() & 0xFF) << 8) |
+      ((b.getValue() & 0xFF) << 0);
+
+    return new PortugolVar("inteiro", value, false, true);
+  },
+
+  definir_cor(cor) {
+    self.runtime.expectType("definir_cor", "cor", cor, "inteiro", "real");
+    self.runtime.assertGraphicsContext();
+
+    self.graphics.setWorkingColor(
+      Math.round(cor.getValue())
+    );
+  },
+
+  obter_RGB(cor, canal) {
+    self.runtime.expectType("obter_RGB", "cor", cor, "inteiro", "real");
+    self.runtime.expectType("obter_RGB", "canal", canal, "inteiro");
+
+    const color = Math.round(cor.getValue());
+    const channel = canal.getValue();
+
+    switch (channel) {
+      case 0: return new PortugolVar("inteiro", (color >> 16) & 0xFF, false, true);
+      case 1: return new PortugolVar("inteiro", (color >> 8) & 0xFF, false, true);
+      case 2: return new PortugolVar("inteiro", color & 0xFF, false, true);
+      default: throw new Error("O canal informado (" + channel + ") é inválido, o canal deve ser um dos seguintes valores: 0 (R); 1 (G); 2 (B)");
+    }
+  },
+
+  definir_gradiente(tipo, cor1, cor2) {
+    self.runtime.expectType("definir_gradiente", "tipo", tipo, "inteiro");
+    self.runtime.expectType("definir_gradiente", "cor1", cor1, "inteiro", "real");
+    self.runtime.expectType("definir_gradiente", "cor2", cor2, "inteiro", "real");
+
+    self.runtime.assertGraphicsContext();
+
+    self.graphics.setWorkingGradient(
+      tipo.getValue(),
+      Math.round(cor1.getValue()),
+      Math.round(cor2.getValue())
+    );
+  },
+
+  definir_opacidade(opacidade) {
+    self.runtime.expectType("definir_opacidade", "opacidade", opacidade, "inteiro", "real");
+    self.runtime.assertGraphicsContext();
+    self.graphics.setWorkingOpacity(opacidade.getValue());
+  },
+
+  definir_estilo_texto(italico, negrito, sublinhado) {
+    self.runtime.expectType("definir_estilo_texto", "italico", italico, "logico");
+    self.runtime.expectType("definir_estilo_texto", "negrito", negrito, "logico");
+    self.runtime.expectType("definir_estilo_texto", "sublinhado", sublinhado, "logico");
+
+    self.runtime.assertGraphicsContext();
+
+    self.graphics.setWorkingTextStyle(
+      italico.getValue(),
+      negrito.getValue(),
+      sublinhado.getValue()
+    );
+  },
+
+  definir_tamanho_texto(tamanho) {
+    self.runtime.expectType("definir_tamanho_texto", "tamanho", tamanho, "inteiro", "real");
+    self.runtime.assertGraphicsContext();
+    self.graphics.setWorkingTextSize(tamanho.getValue());
+  },
+
+  definir_fonte_texto(fonte) {
+    self.runtime.expectType("definir_fonte_texto", "fonte", fonte, "cadeia");
+    self.runtime.assertGraphicsContext();
+    self.graphics.setWorkingFont(fonte.getValue());
+  },
+
+  definir_rotacao(rotacao) {
+    self.runtime.expectType("definir_rotacao", "rotacao", rotacao, "inteiro", "real");
+    self.runtime.assertGraphicsContext();
+    self.graphics.setWorkingRotation(rotacao.getValue());
+  },
+
+  limpar() {
+    self.runtime.assertGraphicsContext();
+    self.graphics.clearRender();
+  },
+
+  desenhar_retangulo(x, y, largura, altura, arrendodar_cantos, preencher) {
+    self.runtime.expectType("desenhar_retangulo", "x", x, "inteiro", "real");
+    self.runtime.expectType("desenhar_retangulo", "y", y, "inteiro", "real");
+    self.runtime.expectType("desenhar_retangulo", "largura", largura, "inteiro", "real");
+    self.runtime.expectType("desenhar_retangulo", "altura", altura, "inteiro", "real");
+    self.runtime.expectType("desenhar_retangulo", "arrendodar_cantos", arrendodar_cantos, "logico");
+    self.runtime.expectType("desenhar_retangulo", "preencher", preencher, "logico");
+
+    self.runtime.assertGraphicsContext();
+
+    self.graphics.drawRect(x.getValue(), y.getValue(), largura.getValue(), altura.getValue(), arrendodar_cantos.getValue(), preencher.getValue());
+  },
+
+  desenhar_elipse(x, y, largura, altura, preencher) {
+    self.runtime.expectType("desenhar_elipse", "x", x, "inteiro", "real");
+    self.runtime.expectType("desenhar_elipse", "y", y, "inteiro", "real");
+    self.runtime.expectType("desenhar_elipse", "largura", largura, "inteiro", "real");
+    self.runtime.expectType("desenhar_elipse", "altura", altura, "inteiro", "real");
+    self.runtime.expectType("desenhar_elipse", "preencher", preencher, "logico");
+
+    self.runtime.assertGraphicsContext();
+
+    self.graphics.drawEllipse(x.getValue(), y.getValue(), largura.getValue(), altura.getValue(), preencher.getValue());
+  },
+
+  desenhar_ponto(x, y) {
+    self.runtime.expectType("desenhar_ponto", "x", x, "inteiro", "real");
+    self.runtime.expectType("desenhar_ponto", "y", y, "inteiro", "real");
+
+    self.runtime.assertGraphicsContext();
+
+    self.graphics.drawPoint(x.getValue(), y.getValue());
+  },
+
+  desenhar_poligono(pontos, preencher) {
+    self.runtime.expectType("desenhar_poligono", "pontos", pontos, "matriz");
+    self.runtime.expectType("desenhar_poligono", "preencher", preencher, "logico");
+
+    self.runtime.assertGraphicsContext();
+
+    self.graphics.drawPolygon(pontos.getValue(), preencher.getValue());
+  },
+
+  desenhar_texto(x, y, texto) {
+    self.runtime.expectType("desenhar_texto", "x", x, "inteiro", "real");
+    self.runtime.expectType("desenhar_texto", "y", y, "inteiro", "real");
+    self.runtime.expectType("desenhar_texto", "texto", texto, "cadeia");
+
+    self.runtime.assertGraphicsContext();
+
+    self.graphics.drawText(x.getValue(), y.getValue(), texto.getValue());
+  },
+
+  desenhar_linha(x1, y1, x2, y2) {
+    self.runtime.expectType("desenhar_linha", "x1", x1, "inteiro", "real");
+    self.runtime.expectType("desenhar_linha", "y1", y1, "inteiro", "real");
+    self.runtime.expectType("desenhar_linha", "x2", x2, "inteiro", "real");
+    self.runtime.expectType("desenhar_linha", "y2", y2, "inteiro", "real");
+
+    self.runtime.assertGraphicsContext();
+
+    self.graphics.drawLine(x1.getValue(), y1.getValue(), x2.getValue(), y2.getValue());
+  },
+
+  altura_imagem(endereco) {
+    self.runtime.expectType("altura_imagem", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("altura_imagem", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  largura_imagem(endereco) {
+    self.runtime.expectType("largura_imagem", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("largura_imagem", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  carregar_fonte(caminho_fonte) {
+    self.runtime.expectType("carregar_fonte", "caminho_fonte", caminho_fonte, "cadeia");
+    self.runtime.unimplementedMethod("carregar_fonte", "Graficos");
+  },
+
+  carregar_imagem(caminho) {
+    self.runtime.expectType("carregar_imagem", "caminho", caminho, "cadeia");
+    self.runtime.unimplementedMethod("carregar_imagem", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  liberar_imagem(endereco) {
+    self.runtime.expectType("liberar_imagem", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("liberar_imagem", "Graficos");
+  },
+
+  definir_icone_janela(endereco) {
+    self.runtime.expectType("definir_icone_janela", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("definir_icone_janela", "Graficos");
+  },
+
+  definir_quadro_gif(endereco, quadro) {
+    self.runtime.expectType("definir_quadro_gif", "endereco", endereco, "inteiro");
+    self.runtime.expectType("definir_quadro_gif", "quadro", quadro, "inteiro");
+    self.runtime.unimplementedMethod("definir_quadro_gif", "Graficos");
+  },
+
+  desenhar_imagem(x, y, endereco) {
+    self.runtime.expectType("desenhar_imagem", "x", x, "inteiro", "real");
+    self.runtime.expectType("desenhar_imagem", "y", y, "inteiro", "real");
+    self.runtime.expectType("desenhar_imagem", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("desenhar_imagem", "Graficos");
+  },
+
+  desenhar_porcao_imagem(x, y, xi, yi, largura, altura, endereco) {
+    self.runtime.expectType("desenhar_porcao_imagem", "x", x, "inteiro", "real");
+    self.runtime.expectType("desenhar_porcao_imagem", "y", y, "inteiro", "real");
+    self.runtime.expectType("desenhar_porcao_imagem", "xi", xi, "inteiro", "real");
+    self.runtime.expectType("desenhar_porcao_imagem", "yi", yi, "inteiro", "real");
+    self.runtime.expectType("desenhar_porcao_imagem", "largura", largura, "inteiro", "real");
+    self.runtime.expectType("desenhar_porcao_imagem", "altura", altura, "inteiro", "real");
+    self.runtime.expectType("desenhar_porcao_imagem", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("desenhar_porcao_imagem", "Graficos");
+  },
+
+  desenhar_quadro_atual_gif(x, y, endereco) {
+    self.runtime.expectType("desenhar_quadro_atual_gif", "x", x, "inteiro", "real");
+    self.runtime.expectType("desenhar_quadro_atual_gif", "y", y, "inteiro", "real");
+    self.runtime.expectType("desenhar_quadro_atual_gif", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("desenhar_quadro_atual_gif", "Graficos");
+  },
+
+  obter_cor_pixel(endereco, x, y) {
+    self.runtime.expectType("obter_cor_pixel", "endereco", endereco, "inteiro");
+    self.runtime.expectType("obter_cor_pixel", "x", x, "inteiro", "real");
+    self.runtime.expectType("obter_cor_pixel", "y", y, "inteiro", "real");
+    self.runtime.unimplementedMethod("obter_cor_pixel", "Graficos");
+    return new PortugolVar("inteiro", -16777216, false, true);
+  },
+
+  obter_intervalo_gif(endereco) {
+    self.runtime.expectType("obter_intervalo_gif", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("obter_intervalo_gif", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  obter_numero_quadro_atual_gif(endereco) {
+    self.runtime.expectType("obter_numero_quadro_atual_gif", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("obter_numero_quadro_atual_gif", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  obter_numero_quadros_gif(endereco) {
+    self.runtime.expectType("obter_numero_quadros_gif", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("obter_numero_quadros_gif", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  obter_quadro_gif(endereco, quadro) {
+    self.runtime.expectType("obter_quadro_gif", "endereco", endereco, "inteiro");
+    self.runtime.expectType("obter_quadro_gif", "quadro", quadro, "inteiro");
+    self.runtime.unimplementedMethod("obter_quadro_gif", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  proximo_frame_gif(endereco) {
+    self.runtime.expectType("proximo_frame_gif", "endereco", endereco, "inteiro");
+    self.runtime.unimplementedMethod("proximo_frame_gif", "Graficos");
+  },
+
+  redimensionar_imagem(endereco, largura, altura, manter_qualidade) {
+    self.runtime.expectType("redimensionar_imagem", "endereco", endereco, "inteiro");
+    self.runtime.expectType("redimensionar_imagem", "largura", largura, "inteiro", "real");
+    self.runtime.expectType("redimensionar_imagem", "altura", altura, "inteiro", "real");
+    self.runtime.expectType("redimensionar_imagem", "manter_qualidade", manter_qualidade, "logico");
+    self.runtime.unimplementedMethod("redimensionar_imagem", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  renderizar_imagem(largura, altura) {
+    self.runtime.expectType("renderizar_imagem", "largura", largura, "inteiro", "real");
+    self.runtime.expectType("renderizar_imagem", "altura", altura, "inteiro", "real");
+    self.runtime.unimplementedMethod("renderizar_imagem", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  transformar_imagem(endereco, espelhamento_horizontal, espelhamento_vertical, rotacao, cor_transparente) {
+    self.runtime.expectType("transformar_imagem", "endereco", endereco, "inteiro");
+    self.runtime.expectType("transformar_imagem", "espelhamento_horizontal", espelhamento_horizontal, "logico");
+    self.runtime.expectType("transformar_imagem", "espelhamento_vertical", espelhamento_vertical, "logico");
+    self.runtime.expectType("transformar_imagem", "rotacao", rotacao, "inteiro", "real");
+    self.runtime.expectType("transformar_imagem", "cor_transparente", cor_transparente, "inteiro");
+    self.runtime.unimplementedMethod("transformar_imagem", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+
+  transformar_porcao_imagem(endereco, x, y, largura, altura, espelhamento_horizontal, espelhamento_vertical, rotacao, cor_transparente) {
+    self.runtime.expectType("transformar_porcao_imagem", "endereco", endereco, "inteiro");
+    self.runtime.expectType("transformar_porcao_imagem", "x", x, "inteiro", "real");
+    self.runtime.expectType("transformar_porcao_imagem", "y", y, "inteiro", "real");
+    self.runtime.expectType("transformar_porcao_imagem", "largura", largura, "inteiro", "real");
+    self.runtime.expectType("transformar_porcao_imagem", "altura", altura, "inteiro", "real");
+    self.runtime.expectType("transformar_porcao_imagem", "espelhamento_horizontal", espelhamento_horizontal, "logico");
+    self.runtime.expectType("transformar_porcao_imagem", "espelhamento_vertical", espelhamento_vertical, "logico");
+    self.runtime.expectType("transformar_porcao_imagem", "rotacao", rotacao, "inteiro", "real");
+    self.runtime.expectType("transformar_porcao_imagem", "cor_transparente", cor_transparente, "inteiro");
+    self.runtime.unimplementedMethod("transformar_porcao_imagem", "Graficos");
+    return new PortugolVar("inteiro", 0, false, true);
+  },
+}`;

--- a/packages/runtime/src/libs/index.ts
+++ b/packages/runtime/src/libs/index.ts
@@ -1,4 +1,5 @@
 import Calendario from "./Calendario.js";
+import Graficos from "./Graficos.js";
 import Matematica from "./Matematica.js";
 import Texto from "./Texto.js";
 import Tipos from "./Tipos.js";
@@ -6,6 +7,7 @@ import Util from "./Util.js";
 
 export const portugolLibs = /* javascript */ `{
   Calendario: ${Calendario},
+  Graficos: ${Graficos},
   Matematica: ${Matematica},
   Texto: ${Texto},
   Tipos: ${Tipos},

--- a/packages/runtime/src/runtime/PortugolRuntime.ts
+++ b/packages/runtime/src/runtime/PortugolRuntime.ts
@@ -4,6 +4,7 @@ export const portugolRuntime = /* javascript */ `
 class PortugolRuntime {
   globalScope = {};
   currentFunction = null;
+  debug = false;
 
   constructor(initScope) {
     this.initScope = initScope;
@@ -14,6 +15,12 @@ class PortugolRuntime {
     };
 
     this.libs = ${portugolLibs};
+  }
+
+  DEBUG(...args) {
+    if (this.debug) {
+      console.log(...args);
+    }
   }
 
   getScope(baseScope) {
@@ -82,7 +89,7 @@ class PortugolRuntime {
 
     while (args.length) {
       const arg = args.pop();
-      console.log("assign", { initial, arg });
+      this.DEBUG("assign", { initial, arg });
 
       if (typeof arg === "undefined") {
         throw new Error("Não é possível atribuir uma variável não declarada a uma variável declarada");
@@ -107,7 +114,7 @@ class PortugolRuntime {
       initial = arg;
     }
 
-    console.log("assign.final", { initial });
+    this.DEBUG("assign.final", { initial });
 
     return initial;
   }
@@ -166,23 +173,23 @@ class PortugolRuntime {
   }
 
   concat(args) {
-    console.log("concat.preinit", { args });
+    this.DEBUG("concat.preinit", { args });
 
     let result = args.shift().clone();
 
     while (args.length) {
       let arg = args.shift().clone();
-      console.log("concat.ongoing", { arg, result });
+      this.DEBUG("concat.ongoing", { arg, result });
 
       result.value += arg.stringValue();
     }
 
-    console.log("concat.finish", { result });
+    this.DEBUG("concat.finish", { result });
     return new PortugolVar("cadeia", result.value);
   }
 
   mathOperation(op, args) {
-    console.log("mathOperation.preinit", { op, args });
+    this.DEBUG("mathOperation.preinit", { op, args });
 
     let result = args.shift().clone();
 
@@ -190,11 +197,11 @@ class PortugolRuntime {
       return self.runtime.concat([result, ...args]);
     }
 
-    console.log("mathOperation.init", { op, args, result });
+    this.DEBUG("mathOperation.init", { op, args, result });
 
     while (args.length) {
       let arg = args.shift().clone();
-      console.log("mathOperation.ongoing", { arg, result });
+      this.DEBUG("mathOperation.ongoing", { arg, result });
 
       if (!["real", "inteiro"].includes(arg.type)) {
         const mathOpDesc = {
@@ -236,16 +243,16 @@ class PortugolRuntime {
       }
     }
 
-    console.log("mathOperation.finish", { result });
+    this.DEBUG("mathOperation.finish", { result });
     return result;
   }
 
   comparativeOperation(op, args) {
-    console.log("comparativeOp.preinit", { op, args });
+    this.DEBUG("comparativeOp.preinit", { op, args });
     let result = args.shift().value;
 
     while (args.length) {
-      console.log("comparativeOp.ongoing", { op, args, result });
+      this.DEBUG("comparativeOp.ongoing", { op, args, result });
       let arg = args.shift().value;
 
       switch (op) {
@@ -286,20 +293,20 @@ class PortugolRuntime {
       }
     }
 
-    console.log("comparativeOp.finish", { result });
+    this.DEBUG("comparativeOp.finish", { result });
     return new PortugolVar("logico", result);
   }
 
   bitwiseOperation(op, args) {
-    console.log("bitwiseOperation.preinit", { op, args });
+    this.DEBUG("bitwiseOperation.preinit", { op, args });
 
     let result = args.shift().clone();
 
-    console.log("bitwiseOperation.init", { op, args, result });
+    this.DEBUG("bitwiseOperation.init", { op, args, result });
 
     while (args.length) {
       let arg = args.shift().clone();
-      console.log("bitwiseOperation.ongoing", { arg, result });
+      this.DEBUG("bitwiseOperation.ongoing", { arg, result });
 
       if (arg.type !== "inteiro" || result.type !== "inteiro") {
         const bitwiseOpDesc = {
@@ -341,12 +348,12 @@ class PortugolRuntime {
       }
     }
 
-    console.log("bitwiseOperation.finish", { result });
+    this.DEBUG("bitwiseOperation.finish", { result });
     return result;
   }
 
   applyModifier(mod, item) {
-    console.log("applyModifier.init", { mod, item });
+    this.DEBUG("applyModifier.init", { mod, item });
     const result = item.clone();
 
     switch (mod) {
@@ -370,7 +377,7 @@ class PortugolRuntime {
         throw new Error("Modificador inválido: " + mod);
     }
 
-    console.log("applyModifier.finish", { result });
+    this.DEBUG("applyModifier.finish", { result });
     return result;
   }
 
@@ -404,6 +411,50 @@ class PortugolRuntime {
         throw new Error("Tipos incompatíveis! O " + (i + 1) + "º parâmetro da função '" + this.currentFunction + "', '" + params[i].name + "', espera uma expressão do tipo '" + params[i].type + "', mas foi passada uma expressão do tipo '" + args[i].type + "'.");
       }
     }
+  }
+
+  assertGraphicsContext() {
+    if (!self.graphics) {
+      throw new Error("O modo gráfico não foi inicializado");
+    }
+  }
+
+  postMessage(message) {
+    message.id = Math.random().toString(36).substr(2, 9);
+
+    self.postMessage({
+      type: "message",
+      message,
+    });
+  }
+
+  postMessageAndWaitForResponse(message) {
+    this.postMessage(message);
+    return this.waitForMessageResponse(message);
+  }
+
+  async waitForMessageResponse(message) {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const result = await new Promise((resolve) => {
+      self.addEventListener("message", (receivedMessage) => {
+        if (
+          receivedMessage.data &&
+          receivedMessage.data.type === "message-reply" &&
+          receivedMessage.data.id === message.id
+        ) {
+          controller.abort();
+          resolve(receivedMessage.data.result);
+        }
+      }, { signal });
+    });
+
+    return result;
+  }
+
+  unimplementedMethod(methodName, library) {
+    throw new Error("O método '" + methodName + "'" + (library ? " da biblioteca '" + library + "'" : "") + " ainda não foi implementado e não pode ser chamado.");
   }
 }
 //endregion

--- a/packages/runtime/src/runtime/PortugolRuntime.ts
+++ b/packages/runtime/src/runtime/PortugolRuntime.ts
@@ -247,56 +247,6 @@ class PortugolRuntime {
     return result;
   }
 
-  comparativeOperation(op, args) {
-    this.DEBUG("comparativeOp.preinit", { op, args });
-    let result = args.shift().value;
-
-    while (args.length) {
-      this.DEBUG("comparativeOp.ongoing", { op, args, result });
-      let arg = args.shift().value;
-
-      switch (op) {
-        case "==":
-          result = result == arg;
-          break;
-
-        case "!=":
-          result = result != arg;
-          break;
-
-        case ">":
-          result = result > arg;
-          break;
-
-        case ">=":
-          result = result >= arg;
-          break;
-
-        case "<":
-          result = result < arg;
-          break;
-
-        case "<=":
-          result = result <= arg;
-          break;
-
-        case "&&":
-          result = result && arg;
-          break;
-
-        case "||":
-          result = result || arg;
-          break;
-
-        default:
-          throw new Error("Operação comparativa inválida: " + op);
-      }
-    }
-
-    this.DEBUG("comparativeOp.finish", { result });
-    return new PortugolVar("logico", result);
-  }
-
   bitwiseOperation(op, args) {
     this.DEBUG("bitwiseOperation.preinit", { op, args });
 

--- a/packages/runtime/src/runtime/PortugolVar.ts
+++ b/packages/runtime/src/runtime/PortugolVar.ts
@@ -22,6 +22,22 @@ class PortugolVar {
     }
   }
 
+  getValue() {
+    if (Array.isArray(this.value)) {
+      const handleValue = (value) => {
+        if (value instanceof PortugolVar) {
+          return value.value;
+        }
+
+        return value;
+      };
+
+      return this.value.map(handleValue);
+    }
+
+    return this.value;
+  }
+
   toString() {
     switch (this.type) {
       case "caracter":

--- a/packages/runtime/src/runtime/index.ts
+++ b/packages/runtime/src/runtime/index.ts
@@ -1,9 +1,11 @@
+import { portugolGraphicsContext } from "../graphics/PortugolGraphicsContext.js";
 import { portugolRuntime } from "./PortugolRuntime.js";
 import { portugolVar } from "./PortugolVar.js";
 
 export const runtime = /* javascript */ `
 //region Runtime
 ${portugolVar}
+${portugolGraphicsContext}
 ${portugolRuntime}
 //endregion
 `;


### PR DESCRIPTION
Problema relatado pela issue #228.

O problema estava ocorrendo pois **todas** as **condições** nas **operações lógicas** estavam sendo executadas independente de ordem ou resultado.

Por exemplo, se tivermos o seguinte código:

```portugol
inteiro vetor[] = {1, 2, 3}
inteiro tamanho = 3
inteiro indice = 3

se ((indice < tamanho) e (vetor[indice] > 3)) {
  escreva("abc")
}
```

O Portugol Webstudio irá transpilar essa condição para:

```javascript
if (
  runtime.comparativeOperation("&&", [
    (
      runtime.comparativeOperation("<", [
        scope.variables["indice"],
        scope.variables["tamanho"],
      ])
    ),
    (
      runtime.comparativeOperation(">", [
        scope.variables["vetor"].value[
          scope.variables["indice"].value
        ],
        new PortugolVar("inteiro", 3),
      ])
    ),
  ])
  .value === true
) { }
```

Nesse caso, por não estar fazendo a operação lógica **diretamente** e sim na função `comparativeOperation`, todas as condições estavam sendo executadas, independentemente se a primeira condição fosse *falsa* ou *verdadeira*.

Só que como a segunda condição está obtendo um valor do vetor, o código dá o seguinte erro na execução:

```
⛔ Cannot read properties of undefined (reading 'value')

Programa finalizado. Tempo de execução: 41 milissegundos
```

A solução realizada nessa fix foi então remover a função `comparativeOperation` e realizar as operações lógicas diretamente.

```javascript
if (
  new PortugolVar("logico", (
    (
      new PortugolVar("logico", (
        scope.variables["indice"].value < 
        scope.variables["tamanho"].value
      ))
    ).value && 
    (
      new PortugolVar("logico", (
        scope.variables["vetor"].value[
          scope.variables["indice"].value
        ].value > 
        new PortugolVar("inteiro", 3).value
      ))
    ).value
  ))
  .value === true
) { }
```

Dessa forma, a segunda condição **não** será executada e o código não irá dar o erro, assim como numa execução de algoritmo padrão.