### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deloy-beta.yml
+++ b/.github/workflows/deloy-beta.yml
@@ -1,4 +1,6 @@
 name: Build and Deploy (Beta)
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/dgadelha/Portugol-Webstudio/security/code-scanning/6](https://github.com/dgadelha/Portugol-Webstudio/security/code-scanning/6)

To address this problem, we should add a `permissions` block explicitly limiting the permissions granted to the GITHUB_TOKEN for this workflow. Because the deployment uses Firebase credentials provided via secrets (not GITHUB_TOKEN), and there is no evidence in this workflow of needing to write to repository contents, the minimal required permissions seem to be just `contents: read`. This should be added at the root workflow level (directly under `name` and `on`) so that it applies to all jobs. No other changes or imports are needed, and no existing functionality will be affected. The fix consists of adding:

```yaml
permissions:
  contents: read
```

as line 2, pushing everything else down.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
